### PR TITLE
Marks local web server test as a webtest

### DIFF
--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -160,8 +160,8 @@ class TestInstalledAppFlow(object):
             client_secret=CLIENT_SECRETS_INFO['web']['client_secret'],
             code=mock.sentinel.code)
 
-    @mock.patch('google_auth_oauthlib.flow.webbrowser', autospec=True)
     @pytest.mark.webtest
+    @mock.patch('google_auth_oauthlib.flow.webbrowser', autospec=True)
     def test_run_local_server(
             self, webbrowser_mock, instance, mock_fetch_token):
         auth_redirect_url = urllib.parse.urljoin(

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -161,6 +161,7 @@ class TestInstalledAppFlow(object):
             code=mock.sentinel.code)
 
     @mock.patch('google_auth_oauthlib.flow.webbrowser', autospec=True)
+    @pytest.mark.webtest
     def test_run_local_server(
             self, webbrowser_mock, instance, mock_fetch_token):
         auth_redirect_url = urllib.parse.urljoin(


### PR DESCRIPTION
Once imported internally, we'll use this to control test execution.