### PR TITLE
Accept redirect_uri as arg to flow creating classmethods.

### DIFF
--- a/google_auth_oauthlib/flow.py
+++ b/google_auth_oauthlib/flow.py
@@ -115,8 +115,7 @@ class Flow(object):
         self.redirect_uri = redirect_uri
 
     @classmethod
-    def from_client_config(
-            cls, client_config, scopes, redirect_uri=None, **kwargs):
+    def from_client_config(cls, client_config, scopes, **kwargs):
         """Creates a :class:`requests_oauthlib.OAuth2Session` from client
         configuration loaded from a Google-format client secrets file.
 
@@ -151,11 +150,11 @@ class Flow(object):
             google_auth_oauthlib.helpers.session_from_client_config(
                 client_config, scopes, **kwargs))
 
+        redirect_uri = kwargs.get('redirect_uri', None)
         return cls(session, client_type, client_config, redirect_uri)
 
     @classmethod
-    def from_client_secrets_file(
-            cls, client_secrets_file, scopes, redirect_uri=None, **kwargs):
+    def from_client_secrets_file(cls, client_secrets_file, scopes, **kwargs):
         """Creates a :class:`Flow` instance from a Google client secrets file.
 
         Args:
@@ -172,8 +171,7 @@ class Flow(object):
         with open(client_secrets_file, 'r') as json_file:
             client_config = json.load(json_file)
 
-        return cls.from_client_config(
-            client_config, scopes=scopes, redirect_uri=redirect_uri, **kwargs)
+        return cls.from_client_config(client_config, scopes=scopes, **kwargs)
 
     @property
     def redirect_uri(self):

--- a/google_auth_oauthlib/flow.py
+++ b/google_auth_oauthlib/flow.py
@@ -115,7 +115,7 @@ class Flow(object):
         self.redirect_uri = redirect_uri
 
     @classmethod
-    def from_client_config(cls, client_config, scopes, **kwargs):
+    def from_client_config(cls, client_config, scopes, redirect_uri=None, **kwargs):
         """Creates a :class:`requests_oauthlib.OAuth2Session` from client
         configuration loaded from a Google-format client secrets file.
 
@@ -150,10 +150,10 @@ class Flow(object):
             google_auth_oauthlib.helpers.session_from_client_config(
                 client_config, scopes, **kwargs))
 
-        return cls(session, client_type, client_config)
+        return cls(session, client_type, client_config, redirect_uri)
 
     @classmethod
-    def from_client_secrets_file(cls, client_secrets_file, scopes, **kwargs):
+    def from_client_secrets_file(cls, client_secrets_file, scopes, redirect_uri=None, **kwargs):
         """Creates a :class:`Flow` instance from a Google client secrets file.
 
         Args:
@@ -170,7 +170,8 @@ class Flow(object):
         with open(client_secrets_file, 'r') as json_file:
             client_config = json.load(json_file)
 
-        return cls.from_client_config(client_config, scopes=scopes, **kwargs)
+        return cls.from_client_config(
+            client_config, scopes=scopes, redirect_uri=redirect_uri, **kwargs)
 
     @property
     def redirect_uri(self):

--- a/google_auth_oauthlib/flow.py
+++ b/google_auth_oauthlib/flow.py
@@ -115,7 +115,8 @@ class Flow(object):
         self.redirect_uri = redirect_uri
 
     @classmethod
-    def from_client_config(cls, client_config, scopes, redirect_uri=None, **kwargs):
+    def from_client_config(
+            cls, client_config, scopes, redirect_uri=None, **kwargs):
         """Creates a :class:`requests_oauthlib.OAuth2Session` from client
         configuration loaded from a Google-format client secrets file.
 
@@ -153,7 +154,8 @@ class Flow(object):
         return cls(session, client_type, client_config, redirect_uri)
 
     @classmethod
-    def from_client_secrets_file(cls, client_secrets_file, scopes, redirect_uri=None, **kwargs):
+    def from_client_secrets_file(
+            cls, client_secrets_file, scopes, redirect_uri=None, **kwargs):
         """Creates a :class:`Flow` instance from a Google client secrets file.
 
         Args:

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -40,6 +40,15 @@ class TestFlow(object):
                 CLIENT_SECRETS_INFO['web']['client_id'])
         assert instance.oauth2session.scope == mock.sentinel.scopes
 
+    def test_from_client_secrets_file_with_redirect_uri(self):
+        instance = flow.Flow.from_client_secrets_file(
+            CLIENT_SECRETS_FILE, scopes=mock.sentinel.scopes,
+            redirect_uri=mock.sentinel.redirect_uri
+        )
+        assert (instance.redirect_uri ==
+                instance.oauth2session.redirect_uri ==
+                mock.sentinel.redirect_uri)
+
     def test_from_client_config_installed(self):
         client_config = {'installed': CLIENT_SECRETS_INFO['web']}
         instance = flow.Flow.from_client_config(
@@ -48,6 +57,16 @@ class TestFlow(object):
         assert (instance.oauth2session.client_id ==
                 client_config['installed']['client_id'])
         assert instance.oauth2session.scope == mock.sentinel.scopes
+
+    def test_from_client_config_with_redirect_uri(self):
+        client_config = {'installed': CLIENT_SECRETS_INFO['web']}
+        instance = flow.Flow.from_client_config(
+            client_config, scopes=mock.sentinel.scopes,
+            redirect_uri=mock.sentinel.redirect_uri
+        )
+        assert (instance.redirect_uri ==
+                instance.oauth2session.redirect_uri ==
+                mock.sentinel.redirect_uri)
 
     def test_from_client_config_bad_format(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
The [flow.py docstring](https://github.com/GoogleCloudPlatform/google-auth-library-python-oauthlib/blob/d4f8fd8dd895c0c3bbb0775e70e9c6433f320737/google_auth_oauthlib/flow.py#L27) tells that I could pass redirect_uri as argument to the classmethods `from_client_secrets_file` or `from_config_file`, but this thing is broken with the 0.1.1 updates.

I can still set the redirect_uri myself manually, but in this case, the docstring should be updated. I prefer to keep this approach, I mean, keep the redirect_uri as argument to the classmethods ;)

I also updated the tests, let me know if I missed anything.