### PR TITLE
Populate id_token into credentials from oauth2 session

### DIFF
--- a/google_auth_oauthlib/helpers.py
+++ b/google_auth_oauthlib/helpers.py
@@ -21,6 +21,7 @@ Typically, you'll want to use the higher-level helpers in
 .. _requests-oauthlib: http://requests-oauthlib.readthedocs.io/en/stable/
 """
 
+import datetime
 import json
 
 import google.oauth2.credentials
@@ -128,10 +129,13 @@ def credentials_from_session(session, client_config=None):
             'There is no access token for this session, did you call '
             'fetch_token?')
 
-    return google.oauth2.credentials.Credentials(
+    credentials = google.oauth2.credentials.Credentials(
         session.token['access_token'],
         refresh_token=session.token.get('refresh_token'),
         token_uri=client_config.get('token_uri'),
         client_id=client_config.get('client_id'),
         client_secret=client_config.get('client_secret'),
         scopes=session.scope)
+    credentials.expiry = datetime.datetime.fromtimestamp(
+        session.token['expires_at'])
+    return credentials

--- a/google_auth_oauthlib/helpers.py
+++ b/google_auth_oauthlib/helpers.py
@@ -132,6 +132,7 @@ def credentials_from_session(session, client_config=None):
     credentials = google.oauth2.credentials.Credentials(
         session.token['access_token'],
         refresh_token=session.token.get('refresh_token'),
+        id_token=session.token.get('id_token'),
         token_uri=client_config.get('token_uri'),
         client_id=client_config.get('client_id'),
         client_secret=client_config.get('client_secret'),

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -135,6 +135,7 @@ class TestFlow(object):
         instance.oauth2session.token = {
             'access_token': mock.sentinel.access_token,
             'refresh_token': mock.sentinel.refresh_token,
+            'id_token': mock.sentinel.id_token,
             'expires_at': 643969200.0
         }
 
@@ -143,6 +144,7 @@ class TestFlow(object):
         assert credentials.token == mock.sentinel.access_token
         assert credentials.expiry == datetime.datetime(1990, 5, 29, 8, 20, 0)
         assert credentials._refresh_token == mock.sentinel.refresh_token
+        assert credentials.id_token == mock.sentinel.id_token
         assert (credentials._client_id ==
                 CLIENT_SECRETS_INFO['web']['client_id'])
         assert (credentials._client_secret ==
@@ -154,6 +156,7 @@ class TestFlow(object):
         instance.oauth2session.token = {
             'access_token': mock.sentinel.access_token,
             'refresh_token': mock.sentinel.refresh_token,
+            'id_token': mock.sentinel.id_token,
             'expires_at': 643969200.0
         }
 
@@ -177,6 +180,7 @@ class TestInstalledAppFlow(object):
             instance.oauth2session.token = {
                 'access_token': mock.sentinel.access_token,
                 'refresh_token': mock.sentinel.refresh_token,
+                'id_token': mock.sentinel.id_token,
                 'expires_at': 643969200.0
             }
 
@@ -195,6 +199,7 @@ class TestInstalledAppFlow(object):
 
         assert credentials.token == mock.sentinel.access_token
         assert credentials._refresh_token == mock.sentinel.refresh_token
+        assert credentials.id_token == mock.sentinel.id_token
 
         mock_fetch_token.assert_called_with(
             CLIENT_SECRETS_INFO['web']['token_uri'],
@@ -223,6 +228,7 @@ class TestInstalledAppFlow(object):
 
         assert credentials.token == mock.sentinel.access_token
         assert credentials._refresh_token == mock.sentinel.refresh_token
+        assert credentials.id_token == mock.sentinel.id_token
         assert webbrowser_mock.open.called
 
         expected_auth_response = auth_redirect_url.replace('http', 'https')

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import concurrent.futures
+import datetime
 from functools import partial
 import json
 import os
@@ -133,12 +134,14 @@ class TestFlow(object):
     def test_credentials(self, instance):
         instance.oauth2session.token = {
             'access_token': mock.sentinel.access_token,
-            'refresh_token': mock.sentinel.refresh_token
+            'refresh_token': mock.sentinel.refresh_token,
+            'expires_at': 643969200.0
         }
 
         credentials = instance.credentials
 
         assert credentials.token == mock.sentinel.access_token
+        assert credentials.expiry == datetime.datetime(1990, 5, 29, 8, 20, 0)
         assert credentials._refresh_token == mock.sentinel.refresh_token
         assert (credentials._client_id ==
                 CLIENT_SECRETS_INFO['web']['client_id'])
@@ -150,7 +153,8 @@ class TestFlow(object):
     def test_authorized_session(self, instance):
         instance.oauth2session.token = {
             'access_token': mock.sentinel.access_token,
-            'refresh_token': mock.sentinel.refresh_token
+            'refresh_token': mock.sentinel.refresh_token,
+            'expires_at': 643969200.0
         }
 
         session = instance.authorized_session()
@@ -172,7 +176,8 @@ class TestInstalledAppFlow(object):
         def set_token(*args, **kwargs):
             instance.oauth2session.token = {
                 'access_token': mock.sentinel.access_token,
-                'refresh_token': mock.sentinel.refresh_token
+                'refresh_token': mock.sentinel.refresh_token,
+                'expires_at': 643969200.0
             }
 
         fetch_token_patch = mock.patch.object(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import json
 import os
 
@@ -73,13 +74,15 @@ def session():
 def test_credentials_from_session(session):
     session.token = {
         'access_token': mock.sentinel.access_token,
-        'refresh_token': mock.sentinel.refresh_token
+        'refresh_token': mock.sentinel.refresh_token,
+        'expires_at': 643969200.0
     }
 
     credentials = helpers.credentials_from_session(
         session, CLIENT_SECRETS_INFO['web'])
 
     assert credentials.token == mock.sentinel.access_token
+    assert credentials.expiry == datetime.datetime(1990, 5, 29, 8, 20, 0)
     assert credentials._refresh_token == mock.sentinel.refresh_token
     assert credentials._client_id == CLIENT_SECRETS_INFO['web']['client_id']
     assert (credentials._client_secret ==

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -75,6 +75,7 @@ def test_credentials_from_session(session):
     session.token = {
         'access_token': mock.sentinel.access_token,
         'refresh_token': mock.sentinel.refresh_token,
+        'id_token': mock.sentinel.id_token,
         'expires_at': 643969200.0
     }
 
@@ -84,6 +85,7 @@ def test_credentials_from_session(session):
     assert credentials.token == mock.sentinel.access_token
     assert credentials.expiry == datetime.datetime(1990, 5, 29, 8, 20, 0)
     assert credentials._refresh_token == mock.sentinel.refresh_token
+    assert credentials.id_token == mock.sentinel.id_token
     assert credentials._client_id == CLIENT_SECRETS_INFO['web']['client_id']
     assert (credentials._client_secret ==
             CLIENT_SECRETS_INFO['web']['client_secret'])


### PR DESCRIPTION
Credentials accepts id_token as constructor parameter. The helper function `credentials_from_session` can pass the id_token directly.